### PR TITLE
ASCII -> ANSI

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -70,7 +70,7 @@ impl Color {
         Style::new(self)
     }
 
-    pub(crate) fn ascii_fmt(&self, f: &mut fmt::Write) -> fmt::Result {
+    pub(crate) fn ansi_fmt(&self, f: &mut fmt::Write) -> fmt::Result {
         match *self {
             Color::Unset => Ok(()),
             Color::Default => write!(f, "9"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,28 +154,28 @@
 //! Coloring is supported on Windows beginning with the Windows 10 anniversary
 //! update. Since this update, Windows consoles support ANSI escape sequences.
 //! This support, however, must be explicitly enabled. `yansi` provides the
-//! [`Paint::enable_windows_ascii()`] method to enable ASCII support on Windows
+//! [`Paint::enable_windows_ansi()`] method to enable ANSI support on Windows
 //! consoles when available.
 //!
 //! ```rust
 //! use yansi::Paint;
 //!
-//! // Enable ASCII escape sequence support on Windows consoles.
-//! Paint::enable_windows_ascii();
+//! // Enable ANSI escape sequence support on Windows consoles.
+//! Paint::enable_windows_ansi();
 //! ```
 //!
 //! You may wish to disable coloring on unsupported Windows consoles to avoid
-//! emitting unrecognized ASCII escape sequences:
+//! emitting unrecognized ANSI escape sequences:
 //!
 //! ```rust
 //! use yansi::Paint;
 //!
-//! if cfg!(windows) && !Paint::enable_windows_ascii() {
+//! if cfg!(windows) && !Paint::enable_windows_ansi() {
 //!     Paint::disable();
 //! }
 //! ```
 //!
-//! [`Paint::enable_windows_ascii()`]: Paint::enable_windows_ascii()
+//! [`Paint::enable_windows_ansi()`]: Paint::enable_windows_ansi()
 //!
 //! # Why?
 //!

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -75,7 +75,7 @@ use color::Color;
 ///   * [`Paint::enable()`](Paint::enable())
 ///   * [`Paint::disable()`](Paint::disable())
 ///   * [`Paint::is_enabled()`](Paint::is_enabled())
-///   * [`Paint::enable_windows_ascii()`](Paint::enable_windows_ascii())
+///   * [`Paint::enable_windows_ansi()`](Paint::enable_windows_ansi())
 #[derive(Default, Eq, PartialEq, Ord, PartialOrd, Hash, Copy, Clone)]
 pub struct Paint<T> {
     item: T,
@@ -440,7 +440,7 @@ impl Paint<()> {
         ENABLED.load(Ordering::Acquire)
     }
 
-    /// Enables ASCII terminal escape sequences on Windows consoles when
+    /// Enables ANSI terminal escape sequences on Windows consoles when
     /// possible. Returns `true` if escape sequence support was successfully
     /// enabled and `false` otherwise. On non-Windows targets, this method
     /// always returns `true`.
@@ -454,11 +454,11 @@ impl Paint<()> {
     /// ```rust
     /// use yansi::Paint;
     ///
-    /// // A best-effort Windows ASCII terminal support enabling.
-    /// Paint::enable_windows_ascii();
+    /// // A best-effort Windows ANSI terminal support enabling.
+    /// Paint::enable_windows_ansi();
     /// ```
     #[inline]
-    pub fn enable_windows_ascii() -> bool {
-        ::windows::enable_ascii_colors()
+    pub fn enable_windows_ansi() -> bool {
+        ::windows::enable_ansi_colors()
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -425,12 +425,12 @@ impl Style {
 
         if self.background != Color::Unset {
             write_spliced(&mut splice, f, "4")?;
-            self.background.ascii_fmt(f)?;
+            self.background.ansi_fmt(f)?;
         }
 
         if self.foreground != Color::Unset {
             write_spliced(&mut splice, f, "3")?;
-            self.foreground.ascii_fmt(f)?;
+            self.foreground.ansi_fmt(f)?;
         }
 
         // All the codes end with an `m`.

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -43,7 +43,7 @@ mod windows_console {
         }
     }
 
-    unsafe fn enable_ascii_colors_raw() -> Result<bool, ()> {
+    unsafe fn enable_ansi_colors_raw() -> Result<bool, ()> {
         let stdout_handle = get_handle(STD_OUTPUT_HANDLE)?;
         let stderr_handle = get_handle(STD_ERROR_HANDLE)?;
 
@@ -56,14 +56,14 @@ mod windows_console {
     }
 
     #[inline]
-    pub fn enable_ascii_colors() -> bool {
-        unsafe { enable_ascii_colors_raw().unwrap_or(false) }
+    pub fn enable_ansi_colors() -> bool {
+        unsafe { enable_ansi_colors_raw().unwrap_or(false) }
     }
 }
 
 #[cfg(not(windows))]
 mod windows_console {
-    pub fn enable_ascii_colors() -> bool { true }
+    pub fn enable_ansi_colors() -> bool { true }
 }
 
-pub use self::windows_console::enable_ascii_colors;
+pub use self::windows_console::enable_ansi_colors;


### PR DESCRIPTION
I stumbled over this paragraph in the docs:

> Coloring is supported on Windows beginning with the Windows 10 anniversary update. Since this update, Windows consoles support **_ANSI_** escape sequences. This support, however, must be explicitly enabled. yansi provides the Paint::enable_windows_**_ascii_**() method to enable **_ASCII_** support on Windows consoles when available.

I basically then went and replaced the occurrences of `ASCII` (upper and lower case) with `ANSI`. I'm not sure whether all my replacements were correct.

`cargo +nightly test` still runs fine.