### PR TITLE
Allow testing on Stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ travis-ci = { repository = "SergioBenitez/yansi", branch = "master" }
 [dependencies]
 
 [dev-dependencies]
-parking_lot = { version = "0.5", features = ["nightly"] }
+parking_lot = "0.11.1"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,9 +3,7 @@ extern crate parking_lot;
 use super::Color::*;
 use super::{Paint, Style};
 
-use self::parking_lot::Mutex;
-
-static LOCK: Mutex<()> = Mutex::new(());
+static LOCK: parking_lot::Mutex<()> = parking_lot::const_mutex(());
 
 macro_rules! assert_renders {
     ($($input:expr => $expected:expr,)*) => {


### PR DESCRIPTION
Looks like nightly was only needed for a `const Mutex`, which does work
with the latest `parking_lot`, so this also upgrades it.