### PR TITLE
Document and test MSRV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: rust
 matrix:
   include:
+  # Minimum supported Rust version (MSRV)
+  - rust: 1.54.0
+    script: cargo build --all --all-features --verbose
   - rust: stable
     script: cargo build --all --all-features --verbose
   - rust: beta

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ well as implementation details from [`ansi_term`].
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+## Minimum supported Rust version
+
+The MSRV is currently 1.54.0. The MSRV may be bumped across minor versions.


### PR DESCRIPTION
Hi, and thanks for the library! I'm the maintainer of `pretty_assertions`, and am looking and moving from `ansi_term` to `yansi`. I couldn't find a documented MSRV, but the [build failures](https://github.com/colin-kiegel/rust-pretty-assertions/runs/7939004579?check_suite_focus=true) point to 1.54.0 as a likely candidate (stabilization of [`extended_key_value_attributes`](https://github.com/rust-lang/rust/pull/83366)).

This PR documents the MSRV and adds it to CI, along with a proposed policy (updating MSRV on minor versions is pretty standard I think?).

Let me know if you think this is okay, or if any updates are required. I'd like to know what your thoughts are on frequency of the MSRV being updated?